### PR TITLE
fix: set external host URI for self refs

### DIFF
--- a/tests/ga4gh/trs/endpoints/test_register_tools.py
+++ b/tests/ga4gh/trs/endpoints/test_register_tools.py
@@ -55,6 +55,7 @@ ENDPOINT_CONFIG_CHARSET_EXPRESSION = {
         },
     },
     "url_prefix": "http",
+    "external_host": "1.2.3.4",
     "external_port": 80,
     "api_path": "ga4gh/trs/v2",
 }
@@ -80,6 +81,7 @@ ENDPOINT_CONFIG_CHARSET_LITERAL = {
         },
     },
     "url_prefix": "http",
+    "external_host": "1.2.3.4",
     "external_port": 80,
     "api_path": "ga4gh/trs/v2",
 }

--- a/tests/ga4gh/trs/test_server.py
+++ b/tests/ga4gh/trs/test_server.py
@@ -56,6 +56,7 @@ ENDPOINT_CONFIG = {
         },
     },
     "url_prefix": "http",
+    "external_host": "1.2.3.4",
     "external_port": 80,
     "api_path": "ga4gh/trs/v2",
 }

--- a/trs_filer/config.yaml
+++ b/trs_filer/config.yaml
@@ -74,5 +74,6 @@ endpoints:
             init: 1
             increment: 1
     url_prefix: http
+    external_host: 1.2.3.4
     external_port: 3888
     api_path: ga4gh/trs/v2

--- a/trs_filer/ga4gh/trs/endpoints/register_tools.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_tools.py
@@ -62,7 +62,7 @@ class RegisterObject:
             conf['tool_version']['meta_version']['init']
         )
         self.url_prefix = conf['url_prefix']
-        self.host_name = current_app.config['FOCA'].server.host
+        self.host_name = conf['external_host']
         self.external_port = conf['external_port']
         self.api_path = conf['api_path']
         # evaluate character set expression or interpret literal string as set


### PR DESCRIPTION
The `self_uri` property in the `Tool` and `ToolVersion` data model should serve as a self reference to the resouce being requested. However, as it currently used the _internal_ host, which is always set to `0.0.0.0/locahlost`, this will only give the expected result when the service is deployed locally. When exposed over the internet, an external IP or domain has to be set. This PR adds a config variable where the domain of the service can be configured. By default it is set to some dummy value `1.2.3.4`, but depending on the deployment, this can be modified to reflect the external host.

Fixes #17 