### PR TITLE
feat: extend data models for tool registration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,4 +17,4 @@ services:
         image: mongo:3.6
         restart: unless-stopped
         ports:
-            - "24017:27017"
+            - "27017:27017"

--- a/trs_filer/api/20200728.1059c7c.openapi.yaml
+++ b/trs_filer/api/20200728.1059c7c.openapi.yaml
@@ -798,14 +798,14 @@ components:
           type: string
           description: A docker registry or a URL to a Singularity registry. Used along
             with image_name to locate a specific image.
-          example:
-            - registry.hub.docker.com
+          # example:
+          #   - registry.hub.docker.com
         image_name:
           type: string
           description: Used in conjunction with a registry_url if provided to locate images.
-          example:
-            - quay.io/seqware/seqware_full/1.1
-            - ubuntu:latest
+          # example:
+          #   - quay.io/seqware/seqware_full/1.1
+          #   - ubuntu:latest
         size:
           type: integer
           description: Size of the container in bytes.

--- a/trs_filer/api/additions.openapi.yaml
+++ b/trs_filer/api/additions.openapi.yaml
@@ -215,16 +215,12 @@ components:
           type: string
           description: Optional url to the checker tool that will exit successfully if
             this tool produced the expected result given test data.
-        meta_version:
-          type: string
-          description: The version of this tool in the registry. Iterates when fields like
-            the description, author, etc. are updated. 
         versions:
           description: A list of versions for this tool.
           type: array
           items:
-            $ref: "#/components/schemas/ToolVersionPost"
-    ToolVersionPost:
+            $ref: "#/components/schemas/ToolVersionRegister"
+    ToolVersionRegister:
       type: object
       description: A tool version describes a particular iteration of a tool as
         described by a reference to a specific image and/or documents.
@@ -251,15 +247,23 @@ components:
           description: This version of a tool is guaranteed to not change over time (for
             example, a  tool built from a tag in git as opposed to a branch). A
             production quality tool  is required to have a checksum
+        images:
+          description: All known docker images (and versions/hashes) used by this tool. If
+            the tool has to evaluate any of the docker images strings at
+            runtime, those ones cannot be reported here.
+          type: array
+          items:
+            $ref: "#/components/schemas/ImageData"
         descriptor_type:
           type: array
           description: The type (or types) of descriptors available.
           items:
             $ref: "#/components/schemas/DescriptorType"
-        meta_version:
-          type: string
-          description: The version of this tool version in the registry. Iterates when
-            fields like the description, author, etc. are updated.
+        containerfile:
+          type: boolean
+          description: Reports if this tool has a containerfile available. (For
+            Docker-based tools, this would indicate the presence of a
+            Dockerfile)
         verified:
           type: boolean
           description: Reports whether this tool has been verified by a specific

--- a/trs_filer/app.py
+++ b/trs_filer/app.py
@@ -1,9 +1,6 @@
-import logging
 import os
 
 from foca.foca import foca
-
-logger = logging.getLogger(__name__)
 
 
 def main():

--- a/trs_filer/ga4gh/trs/endpoints/register_tools.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_tools.py
@@ -1,5 +1,6 @@
 """Controller for registering new objects."""
 
+import logging
 from random import choice
 import string
 from typing import (Dict, Optional)
@@ -7,8 +8,9 @@ from typing import (Dict, Optional)
 from flask import (current_app, Request)
 from pymongo.errors import DuplicateKeyError
 
-from trs_filer.app import logger
 from trs_filer.errors.exceptions import BadRequest
+
+logger = logging.getLogger(__name__)
 
 
 class RegisterObject:


### PR DESCRIPTION
- Add `images` and `containerfile` properties to `ToolVersionRegister` data model
- Remove `meta_version` property from `ToolRegister` and `ToolVersionRegister` data models