### PR TITLE
Added POST /tools/{id}/versions method

### DIFF
--- a/tests/ga4gh/trs/endpoints/test_register_tools.py
+++ b/tests/ga4gh/trs/endpoints/test_register_tools.py
@@ -296,7 +296,7 @@ def test_create_tool_duplicate_key():
         .collections['files'].client = MagicMock()
     mock = MagicMock(side_effect=[DuplicateKeyError(''), None])
     app.config['FOCA'].db.dbs['trsStore'] \
-        .collections['files'].client.insert_one = mock
+        .collections['files'].client.insert_many = mock
 
     request_data = Dict()
     temp_data = deepcopy(MOCK_REQUEST_DATA_VALID)

--- a/tests/ga4gh/trs/test_server.py
+++ b/tests/ga4gh/trs/test_server.py
@@ -25,9 +25,16 @@ INDEX_CONFIG = {
 COLLECTION_CONFIG = {
     'indexes': [INDEX_CONFIG],
 }
+FILE_INDEX_CONFIG = {
+    'keys': [('tool_id', 1)]
+}
+FILES_CONFIG = {
+    'indexes': [FILE_INDEX_CONFIG],
+}
 DB_CONFIG = {
     'collections': {
         'objects': COLLECTION_CONFIG,
+        'files': FILES_CONFIG,
     },
 }
 MONGO_CONFIG = {

--- a/trs_filer/api/20200728.1059c7c.openapi.yaml
+++ b/trs_filer/api/20200728.1059c7c.openapi.yaml
@@ -880,11 +880,6 @@ components:
             information, and can include a git hash.  Note that this URL should
             resolve to the raw unwrapped content that would otherwise be
             available in content. One of url or content is required.
-          example:
-            descriptorfile:
-              url: https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl
-            containerfile:
-              url: https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/c83478829802b4d36374870843821abe1b625a71/delly_docker/Dockerfile
     Error:
       type: object
       required:

--- a/trs_filer/api/additions.openapi.yaml
+++ b/trs_filer/api/additions.openapi.yaml
@@ -348,44 +348,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Files"
-    FileWrapper:
-      type: object
-      description: >
-        A file provides content for one of
-
-        - A tool descriptor is a metadata document that describes one or more tools.
-
-        - A tool document that describes how to test with one or more sample test
-
-        JSON.
-
-        - A containerfile is a document that describes how to build a particular
-
-        container image. Examples include Dockerfiles for creating Docker images
-
-        and Singularity recipes for Singularity images
-      properties:
-        content:
-          type: string
-          description: The content of the file itself. One of url or content is required.
-        checksum:
-          type: array
-          items:
-            $ref: "#/components/schemas/Checksum"
-          description: "A production (immutable) tool version is required to have a
-            hashcode. Not required otherwise, but might be useful to detect
-            changes. "
-          example:
-            - checksum: ea2a5db69bd20a42976838790bc29294df3af02b
-              type: sha1
-        url:
-          type: string
-          description: Optional url to the underlying content, should include version
-            information, and can include a git hash.  Note that this URL should
-            resolve to the raw unwrapped content that would otherwise be
-            available in content. One of url or content is required.
-          example:
-            url: https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl
     Files:
       description: Properties and (a pointer to the) contents of a file.
       type: object

--- a/trs_filer/api/additions.openapi.yaml
+++ b/trs_filer/api/additions.openapi.yaml
@@ -152,6 +152,63 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  "/tools/{id}/versions":
+    post:
+      summary: Add new versions.
+      description: Add versions to a tool object(given `tool_id`) with a randomly
+        generated unique ID.
+      operationId: postToolVersions
+      tags:
+        - TRS-Filer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: A unique identifier of the tool, scoped to this registry, for
+            example `123456`.
+          schema:
+            type: string
+      requestBody:
+        description: Tool Version(meta)data to add.
+        required: true
+        content:
+          application/json:
+            schema:
+              x-body-name: tool_version
+              type: array
+              items:
+                $ref: '#/components/schemas/ToolVersionRegister'
+      responses:
+        '200':
+          description: The tool was successfully created.
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: The request is malformed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: The request is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: The requester is not authorized to perform this action.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: An unexpected error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     ToolClass:

--- a/trs_filer/api/additions.openapi.yaml
+++ b/trs_filer/api/additions.openapi.yaml
@@ -343,3 +343,54 @@ components:
           type: array
           items:
             type: string
+        files:
+          description: Properties and (pointers to) contents of files associated with a tool.
+          type: array
+          items:
+            $ref: "#/components/schemas/Files"
+    FileWrapper:
+      type: object
+      description: >
+        A file provides content for one of
+
+        - A tool descriptor is a metadata document that describes one or more tools.
+
+        - A tool document that describes how to test with one or more sample test
+
+        JSON.
+
+        - A containerfile is a document that describes how to build a particular
+
+        container image. Examples include Dockerfiles for creating Docker images
+
+        and Singularity recipes for Singularity images
+      properties:
+        content:
+          type: string
+          description: The content of the file itself. One of url or content is required.
+        checksum:
+          type: array
+          items:
+            $ref: "#/components/schemas/Checksum"
+          description: "A production (immutable) tool version is required to have a
+            hashcode. Not required otherwise, but might be useful to detect
+            changes. "
+          example:
+            - checksum: ea2a5db69bd20a42976838790bc29294df3af02b
+              type: sha1
+        url:
+          type: string
+          description: Optional url to the underlying content, should include version
+            information, and can include a git hash.  Note that this URL should
+            resolve to the raw unwrapped content that would otherwise be
+            available in content. One of url or content is required.
+          example:
+            url: https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl
+    Files:
+      description: Properties and (a pointer to the) contents of a file.
+      type: object
+      properties:
+        toolFile:
+          $ref: '#/components/schemas/ToolFile'
+        fileWrapper:
+          $ref: '#/components/schemas/FileWrapper'

--- a/trs_filer/config.yaml
+++ b/trs_filer/config.yaml
@@ -18,6 +18,12 @@ db:
                               id: 1
                           options:
                             'unique': True
+                files:
+                    indexes:
+                        - keys:
+                              tool_id: 1
+                          options:
+                            'unique': True
 
 api:
     specs:

--- a/trs_filer/config.yaml
+++ b/trs_filer/config.yaml
@@ -22,6 +22,7 @@ db:
                     indexes:
                         - keys:
                               tool_id: 1
+                              version_id: 1
                           options:
                             'unique': True
 

--- a/trs_filer/ga4gh/trs/endpoints/register_tools.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_tools.py
@@ -355,7 +355,7 @@ class RegisterToolVersion:
                     self.db_collection_files.replace_one(
                         filter={
                             'tool_id': data_doc['tool_id'],
-                            'versions_id': data_doc['version_id'],
+                            'version_id': data_doc['version_id'],
                         },
                         replacement=data_doc,
                     )

--- a/trs_filer/ga4gh/trs/endpoints/register_tools.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_tools.py
@@ -3,7 +3,7 @@
 import logging
 from random import choice
 import string
-from typing import (Dict, Optional)
+from typing import (Dict, Optional, List)
 
 from flask import (current_app, Request)
 from pymongo.errors import DuplicateKeyError
@@ -34,10 +34,6 @@ class RegisterObject:
                 allowed character set for generating object identifiers.
             tool_id_length: Length of generated object identifiers.
             tool_meta_version_init: Initial value for tool meta version.
-            version_id_charset: Allowed character set or expression evaluating
-                to allowed character set for generating version identifiers.
-            version_id_length: Length of generated version identifiers.
-            versoin_meta_version_init: Initial value for version meta version.
             url_prefix: URL scheme of application. For constructing tool and
                 version `url` properties.
             host_name: Name of application host. For constructing tool and
@@ -58,11 +54,6 @@ class RegisterObject:
         self.tool_id_charset = conf['tool']['id']['charset']
         self.tool_id_length = int(conf['tool']['id']['length'])
         self.tool_meta_version_init = int(conf['tool']['meta_version']['init'])
-        self.version_id_charset = conf['tool_version']['id']['charset']
-        self.version_id_length = int(conf['tool_version']['id']['length'])
-        self.version_meta_version_init = int(
-            conf['tool_version']['meta_version']['init']
-        )
         self.url_prefix = conf['url_prefix']
         self.host_name = conf['external_host']
         self.external_port = conf['external_port']
@@ -72,12 +63,6 @@ class RegisterObject:
             self.tool_id_charset = eval(self.tool_id_charset)
         except Exception:
             self.tool_id_charset = ''.join(sorted(set(self.tool_id_charset)))
-        try:
-            self.version_id_charset = eval(self.version_id_charset)
-        except Exception:
-            self.version_id_charset = ''.join(
-                sorted(set(self.version_id_charset))
-            )
 
     def register_object(self) -> Dict:
         """Register tool with TRS.
@@ -90,7 +75,6 @@ class RegisterObject:
 
         # set unique ID, dependent values and register object
         while True:
-
             # set random tool ID unless ID is provided
             if 'id' not in self.tool_data:
                 replace = False
@@ -109,7 +93,12 @@ class RegisterObject:
 
             # process version information
             if 'versions' in self.tool_data:
-                self.add_versions()
+                version_controller = RegisterToolVersion(
+                    version_data=self.tool_data['versions'],
+                    id=self.tool_data['id'],
+                )
+                self.tool_data['versions'] = version_controller \
+                    .create_update_versions()
 
             # update(insert) tool in(to) database
             if replace:
@@ -126,23 +115,118 @@ class RegisterObject:
 
             logger.info(f"Created tool with id: {self.tool_data['id']}")
             break
-
         return self.tool_data
+
+    def generate_id(
+        self,
+        charset: str = ''.join([string.ascii_letters, string.digits]),
+        length: int = 6,
+    ) -> str:
+        """Generate random string based on allowed set of characters.
+
+        Args:
+            charset: String of allowed characters.
+            length: Length of returned string.
+
+        Returns:
+            Random string of specified length and composed of defined set of
+            allowed characters.
+        """
+        return ''.join(choice(charset) for __ in range(length))
+
+
+class RegisterToolVersion:
+    """Class to register tools with the service."""
+
+    def __init__(
+        self,
+        request: Optional[Request] = None,
+        version_data: Optional[List] = None,
+        id: Optional[str] = None,
+        append: bool = False,
+    ) -> None:
+        """Initialize tool data.
+
+        Args:
+            id: Tool ID.
+            version_data: Version list information.
+            request: API request object. Used if version_data not available.
+            append: Boolean flag to differentiate different instance. False if
+                complete version list changed, other wise True if a new version
+                needs to be appended.
+
+        Attributes:
+            append: Flag to check if new version is being added or entire
+                version list is being updated.
+            tool_id: Tool data id that needs to be updated.
+            version_data: New version list with which old version list will be
+                updated/replaced.
+            db_collection: Database collection storing tool objects.
+            version_id_charset: Allowed character set or expression evaluating
+                to allowed character set for generating version identifiers.
+            version_id_length: Length of generated version identifiers.
+            versoin_meta_version_init: Initial value for version meta version.
+            url_prefix: URL scheme of application. For constructing tool and
+                version `url` properties.
+            host_name: Name of application host. For constructing tool and
+                version `url` properties.
+            external_port: Port at which application is served. For
+                constructing tool and version `url` properties.
+            api_path: Base path at which API endpoints can be reached. For
+                constructing tool and version `url` properties.
+        """
+        self.append = append
+        self.tool_id = id if id else None
+
+        if version_data is not None:
+            self.version_data = version_data
+        if request:
+            self.version_data = request.json
+
+        self.db_collection = (
+            current_app.config['FOCA'].db.dbs['trsStore']
+            .collections['objects'].client
+        )
+        conf = current_app.config['FOCA'].endpoints
+        self.version_id_charset = conf['tool_version']['id']['charset']
+        self.version_id_length = int(conf['tool_version']['id']['length'])
+        self.version_meta_version_init = int(
+            conf['tool_version']['meta_version']['init']
+        )
+        self.url_prefix = conf['url_prefix']
+        self.host_name = conf['external_host']
+        self.external_port = conf['external_port']
+        self.api_path = conf['api_path']
+        # evaluate character set expression or interpret literal string as set
+        try:
+            self.version_id_charset = eval(self.version_id_charset)
+        except Exception:
+            self.version_id_charset = ''.join(
+                sorted(set(self.version_id_charset))
+            )
 
     def add_versions(
         self,
-    ) -> None:
-        """Adds version properties."""
+        versions: List[Dict]
+    ) -> List[Dict]:
+        """Adds version properties.
+
+        Args:
+            versions: New/updated version list.
+
+        Returns:
+            Version list with added db properties.
+        """
         # get list of available version IDs
         version_list = [
-            v.get('id', None) for v in self.tool_data.get('versions', None)
+            v.get('id', None) for v in versions
         ]
 
         # ensure that all supplied version IDs are unique
         if len(version_list) != len(set(version_list)):
             raise BadRequest
 
-        for version in self.tool_data['versions']:
+        for version in versions:
 
             # set version meta version
             version['meta_version'] = str(self.version_meta_version_init)
@@ -165,9 +249,10 @@ class RegisterObject:
             # set version self reference URL
             version['url'] = (
                 f"{self.url_prefix}://{self.host_name}:{self.external_port}/"
-                f"{self.api_path}/tools/{self.tool_data['id']}/versions/"
+                f"{self.api_path}/tools/{self.tool_id}/versions/"
                 f"{version['id']}"
             )
+        return versions
 
     def generate_id(
         self,
@@ -185,3 +270,19 @@ class RegisterObject:
             allowed characters.
         """
         return ''.join(choice(charset) for __ in range(length))
+
+    def create_update_versions(self):
+        """Create/Updates version list.
+
+        Returns:
+            Updated new version list.
+        """
+        if self.tool_id and self.append:
+            old_version = self.db_collection.find_one(
+                filter={"id": self.tool_id},
+                projection={"_id": False, "versions": True}
+            )
+            old_version = old_version['versions']
+            if old_version:
+                self.version_data = old_version+self.version_data
+        return self.add_versions(self.version_data)

--- a/trs_filer/ga4gh/trs/endpoints/register_tools.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_tools.py
@@ -140,9 +140,9 @@ class RegisterToolVersion:
 
     def __init__(
         self,
+        id: str,
         request: Optional[Request] = None,
         version_data: Optional[List] = None,
-        id: Optional[str] = None,
         append: bool = False,
     ) -> None:
         """Initialize tool data.
@@ -176,7 +176,7 @@ class RegisterToolVersion:
                 constructing tool and version `url` properties.
         """
         self.append = append
-        self.tool_id = id if id else None
+        self.tool_id = id
 
         if version_data is not None:
             self.version_data = version_data

--- a/trs_filer/ga4gh/trs/endpoints/register_tools.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_tools.py
@@ -164,6 +164,7 @@ class RegisterToolVersion:
             version_data: New version list with which old version list will be
                 updated/replaced.
             db_collection: Database collection storing tool objects.
+            db_collection_files: Database collection storing tool files.
             version_id_charset: Allowed character set or expression evaluating
                 to allowed character set for generating version identifiers.
             version_id_length: Length of generated version identifiers.
@@ -294,7 +295,7 @@ class RegisterToolVersion:
         """
         return ''.join(choice(charset) for __ in range(length))
 
-    def create_update_versions(self, replace: bool = False):
+    def create_update_versions(self) -> List[Dict]:
         """Create/Updates version list.
 
         Returns:
@@ -310,7 +311,21 @@ class RegisterToolVersion:
                 self.version_data = old_version+self.version_data
         return self.add_versions(self.version_data)
 
-    def check_file_data(self, version_data):
+    def check_file_data(
+        self,
+        version_data: Dict
+    ) -> List[Dict]:
+        """Validates file data corresponding a version.
+
+        Args:
+            version_data: version specific data.
+
+        Returns:
+            List of validated file objects.
+
+        Raises:
+            BadRequest if data not validated.
+        """
         data_files = version_data['files']
         for _file in data_files:
             if 'fileWrapper' in _file:
@@ -327,7 +342,10 @@ class RegisterToolVersion:
                         raise BadRequest
         return version_data['files']
 
-    def create_file_mappings(self):
+    def create_file_mappings(self) -> None:
+        """Create file objcts for every versions of a particular tool
+        object.
+        """
         if self.version_files_map and self.tool_id in self.version_files_map:
             if self.replace:
                 self.db_collection_files.replace_one(

--- a/trs_filer/ga4gh/trs/server.py
+++ b/trs_filer/ga4gh/trs/server.py
@@ -7,6 +7,7 @@ from foca.utils.logging import log_traffic
 
 from trs_filer.ga4gh.trs.endpoints.register_tools import (
     RegisterObject,
+    RegisterToolVersion,
 )
 from trs_filer.errors.exceptions import NotFound
 
@@ -313,3 +314,36 @@ def deleteTool(
         raise NotFound
     else:
         return id
+
+
+@log_traffic
+def postToolVersions(
+    id: str,
+) -> str:
+    """Update tool version list.
+
+    Args:
+        id: Identifier of tool object to be updated.
+
+    Returns:
+        Identifier of the object updated.
+    """
+    version_controller = RegisterToolVersion(
+        id=id,
+        append=True,
+        request=request,
+    )
+    set_versions = version_controller.create_update_versions()
+
+    db_collection = (
+        current_app.config['FOCA'].db.dbs['trsStore']
+        .collections['objects'].client
+    )
+    db_collection.update_one(
+        {'id': id},
+        {
+            '$set': {'versions': set_versions}
+        },
+        upsert=False,
+    )
+    return id


### PR DESCRIPTION
## Description
* Implemented the POST `/tools/{id}/versions` endpoint.
* Now the POST `/tools` endpoint uses the former for adding/updating version information for a given `tool`, hence the code redundancy does not occur.
* Support for additional `ToolVersion` attributes has been added. 
Fixes #33 
Also Fixes #43 
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable

### To do

- [ ] Update the `replace_one` flow for file storage. Current implementation not working ideally when `PUT /tools/{id}` tries to update the file data corresponding a versions.