### PR TITLE
feat: persist database in docker-compose config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,5 +16,7 @@ services:
     mongodb:
         image: mongo:3.6
         restart: unless-stopped
+        volumes:
+            - ../data/trs/db:/data/db
         ports:
             - "27017:27017"


### PR DESCRIPTION
## Description

- Implement database persistence for `docker-compose`-based deployments by adding Docker bind mount for database service to `docker-compose` configuration

Resolves #37 
