### PR TITLE
feat: add "GET .../containerfile"

### DIFF
--- a/tests/ga4gh/trs/endpoints/test_register_objects.py
+++ b/tests/ga4gh/trs/endpoints/test_register_objects.py
@@ -325,6 +325,21 @@ class TestRegisterToolVersion:
             tool.process_metadata()
             assert isinstance(tool.id_charset, str)
 
+    def test_process_metadata_empty_file_object(self):
+        """Test for processing metadata with one empty file object."""
+        app = Flask(__name__)
+        app.config['FOCA'] = Config(
+            db=MongoConfig(**MONGO_CONFIG),
+            endpoints=ENDPOINT_CONFIG_CHARSET_LITERAL,
+        )
+
+        data = deepcopy(MOCK_VERSION_NO_ID)
+        data['files'][0] = {}
+        with app.app_context():
+            tool = RegisterToolVersion(data=data, id=MOCK_ID)
+            tool.process_metadata()
+            assert isinstance(tool.id_charset, str)
+
     def test_register_metadata(self):
         """Test for creating a version with a randomly assigned identifier."""
         app = Flask(__name__)

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -56,15 +56,15 @@ SERVICE_INFO_CONFIG = {
     "name": "My project",
     "organization": {
         "name": "My organization",
-        "url": "https://example.com"
+        "url": "https://example.com",
     },
     "type": {
         "artifact": "beacon",
         "group": "org.ga4gh",
-        "version": "1.0.0"
+        "version": "1.0.0",
     },
     "updatedAt": "2019-06-04T12:58:19Z",
-    "version": "1.0.0"
+    "version": "1.0.0",
 }
 TOOL_CLASS_CONFIG = deepcopy(TOOL_VERSION_CONFIG)
 TOOL_CLASS_CONFIG['validation'] = False
@@ -105,35 +105,44 @@ MOCK_FILES = [
         "fileWrapper": {
             "checksum": [
                 {
-                    "checksum": "ea2a5db69bd20a42976838790bc29294df3af02b",
-                    "type": "sha1"
+                    "checksum": "checksum",
+                    "type": "sha1",
                 }
             ],
-            "content": "string",
-            "url": "sfdlmedl"
+            "content": "content",
+            "url": "url",
         },
         "toolFile": {
             "file_type": "TEST_FILE",
-            "path": "string"
+            "path": "path",
         }
     },
     {
         "fileWrapper": {
             "checksum": [
                 {
-                    "checksum": "ea2a5db69bd20a42976838790bc29294df3af02b",
-                    "type": "sha2"
+                    "checksum": "checksum",
+                    "type": "sha2",
                 }
             ],
-            "content": "string",
-            "url": "sfdlmedl"
+            "content": "content",
+            "url": "url",
         },
         "toolFile": {
             "file_type": "CONTAINERFILE",
-            "path": "string"
+            "path": "path",
         }
-    }
+    },
 ]
+MOCK_FILES_DB_ENTRY = {
+    "id": MOCK_ID,
+    "versions": [
+        {
+            "id": MOCK_ID,
+            "files": MOCK_FILES,
+        }
+    ],
+}
 MOCK_FILES_CONTENT_URL_MISSING = deepcopy(MOCK_FILES)
 del MOCK_FILES_CONTENT_URL_MISSING[0]['fileWrapper']['content']
 del MOCK_FILES_CONTENT_URL_MISSING[0]['fileWrapper']['url']
@@ -143,10 +152,7 @@ MOCK_IMAGES = [
     {
         "checksum": [
             {
-                "checksum": (
-                    "77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1f"
-                    "fb617ac955dd63fb0182"
-                ),
+                "checksum": "checksums",
                 "type": "sha256"
             }
         ],
@@ -154,7 +160,7 @@ MOCK_IMAGES = [
         "image_type": "Docker",
         "registry_host": "registry_host",
         "size": 0,
-        "updated": "updated"
+        "updated": "updated",
     }
 ]
 MOCK_VERSION_NO_ID = {
@@ -174,7 +180,7 @@ MOCK_VERSION_NO_ID = {
     "name": "name",
     "signed": True,
     "verified_source": [
-        "verified_source"
+        "verified_source",
     ]
 }
 MOCK_VERSION_ID = deepcopy(MOCK_VERSION_NO_ID)

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -117,6 +117,22 @@ MOCK_FILES = [
             "path": "string"
         }
     },
+    {
+        "fileWrapper": {
+            "checksum": [
+                {
+                    "checksum": "ea2a5db69bd20a42976838790bc29294df3af02b",
+                    "type": "sha2"
+                }
+            ],
+            "content": "string",
+            "url": "sfdlmedl"
+        },
+        "toolFile": {
+            "file_type": "CONTAINERFILE",
+            "path": "string"
+        }
+    }
 ]
 MOCK_FILES_CONTENT_URL_MISSING = deepcopy(MOCK_FILES)
 del MOCK_FILES_CONTENT_URL_MISSING[0]['fileWrapper']['content']

--- a/trs_filer/api/additions.openapi.yaml
+++ b/trs_filer/api/additions.openapi.yaml
@@ -848,11 +848,6 @@ components:
           description: The type (or types) of descriptors available.
           items:
             $ref: "#/components/schemas/DescriptorType"
-        containerfile:
-          type: boolean
-          description: Reports if this tool has a containerfile available. (For
-            Docker-based tools, this would indicate the presence of a
-            Dockerfile).
         verified:
           type: boolean
           description: Reports whether this tool has been verified by a
@@ -917,11 +912,6 @@ components:
           description: The type (or types) of descriptors available.
           items:
             $ref: "#/components/schemas/DescriptorType"
-        containerfile:
-          type: boolean
-          description: Reports if this tool has a containerfile available. (For
-            Docker-based tools, this would indicate the presence of a
-            Dockerfile).
         verified:
           type: boolean
           description: Reports whether this tool has been verified by a

--- a/trs_filer/ga4gh/trs/endpoints/register_objects.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_objects.py
@@ -292,6 +292,15 @@ class RegisterToolVersion:
             'files': [],
         }
         if 'files' in self.data:
+            # Set `containerfile` property
+            self.data['containerfile'] = False
+            for f in self.data['files']:
+                try:
+                    if f['toolFile']['file_type'] == "CONTAINERFILE":
+                        self.data['containerfile'] = True
+                        break
+                except KeyError:
+                    continue
             self.process_files()
 
     def process_files(self) -> None:

--- a/trs_filer/ga4gh/trs/server.py
+++ b/trs_filer/ga4gh/trs/server.py
@@ -271,9 +271,73 @@ def toolsIdVersionsVersionIdTypeFilesGet(
 def toolsIdVersionsVersionIdContainerfileGet(
     id: str,
     version_id: str,
-) -> List:
-    """Get the container specification(s) for the specified image."""
-    return []  # pragma: no cover
+) -> List[Dict]:
+    """Get the container specification(s) for the specified image.
+
+    Args:
+        id: Unique identifier of the tool.
+        version_id:  Identifier of the tool version for this particular tool.
+
+    Returns:
+        List of wrapped container files objects.
+    """
+
+    tool_version_specs = toolsIdVersionsVersionIdGet.__wrapped__(
+        id=id, version_id=version_id
+    )
+    db_coll_files = (
+        current_app.config['FOCA'].db.dbs['trsStore']
+        .collections['files'].client
+    )
+
+    filt = {
+        'id': id,
+        'versions': {
+            '$elemMatch': {
+                'id': version_id,
+                'files': {
+                    '$elemMatch': {
+                        'toolFile.file_type': 'CONTAINERFILE'
+                    }
+                }
+            }
+        },
+    }
+
+    proj = {
+        '_id': False,
+        'versions': {
+            '$elemMatch': {
+                'id': version_id,
+                'files': {
+                    '$elemMatch': {
+                        'toolFile.file_type': 'CONTAINERFILE'
+                    }
+                }
+            }
+        }
+    }
+
+    if 'containerfile' in tool_version_specs:
+        container_check = tool_version_specs['containerfile']
+    else:
+        container_check = False
+
+    if tool_version_specs and container_check:
+        data = db_coll_files.find_one(
+            filter=filt, projection=proj
+        )
+        try:
+            data = data['versions'][0]
+            ret_array = []
+            for _d in data['files']:
+                if 'fileWrapper' in _d and 'toolFile' in _d:
+                    if _d['toolFile']['file_type'] == 'CONTAINERFILE':
+                        ret_array.append(_d['fileWrapper'])
+            return ret_array
+        except (KeyError, TypeError):
+            raise NotFound
+    raise NotFound
 
 
 @log_traffic


### PR DESCRIPTION
## Description

- Implement `GET /tools/{id}/versions/{version_id}/containerfile` endpoint
- Property `ToolRegisterVersion.containerfile` was removed from specification and is now set by the implementation, based on the availability of any `CONTAINERFILE` associated with that version, as indicated by `files.$.toolFile.file_type`

Fixes #29
Replaces #44 