### PR TITLE
build: update route config to match deployment

### DIFF
--- a/trs_filer/config.yaml
+++ b/trs_filer/config.yaml
@@ -78,9 +78,9 @@ exceptions:
 
 endpoints:
     service:
-        url_prefix: http
-        external_host: 1.2.3.4
-        external_port: 8080
+        url_prefix: https
+        external_host: trs-filer-alex.c03.k8s-popup.csc.fi
+        external_port: 443
         api_path: ga4gh/trs/v2
     service_info:
         id: "TEMPID1"


### PR DESCRIPTION
## Description

- Changing app settings in deployed service currently not supported for Kubernetes-based deployments
- Deployment-specific configuration thus temporarily added to repo/container until a more generic approach at handling app configuration in a deployment-dependent manner has been implemented
- In particular, params were updated such that self reference URLs for tools and tool versions will now point to the TRS-Filer deployment at `https://trs-filer-alex.c03.k8s-popup.csc.fi/ga4gh/trs/v2` 