### PR TITLE
feat: add type info to file registration schema

### DIFF
--- a/tests/ga4gh/trs/test_server.py
+++ b/tests/ga4gh/trs/test_server.py
@@ -10,7 +10,6 @@ import pytest
 from tests.mock_data import (
     ENDPOINT_CONFIG,
     HEADERS_PAGINATION,
-    MOCK_FILES,
     MOCK_FILES_DB_ENTRY,
     MOCK_ID,
     MOCK_TOOL_CLASS,
@@ -18,6 +17,7 @@ from tests.mock_data import (
     MOCK_VERSION_ID,
     MONGO_CONFIG,
     SERVICE_INFO_CONFIG,
+    MOCK_CONTAINER_FILE,
 )
 from trs_filer.ga4gh.trs.server import (
     deleteTool,
@@ -277,7 +277,7 @@ def test_toolsIdVersionsVersionIdContainerfileGet():
             id=MOCK_ID,
             version_id=MOCK_ID,
         )
-        assert res == [MOCK_FILES[1]["fileWrapper"]]
+        assert res == [MOCK_CONTAINER_FILE["file_wrapper"]]
 
 
 def test_toolsIdVersionsVersionIdContainerfileGet_tool_na_NotFound():

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -100,54 +100,109 @@ HEADERS_SERVICE_INFO = {
         "service-info"
     )
 }
+MOCK_TEST_FILE = {
+    "file_wrapper": {
+        "checksum": [
+            {
+                "checksum": "checksum",
+                "type": "sha1",
+            }
+        ],
+        "content": "content",
+        "url": "url",
+    },
+    "tool_file": {
+        "file_type": "TEST_FILE",
+        "path": "path",
+    },
+    "type": "JSON"
+}
+MOCK_DESCRIPTOR_FILE = {
+    "file_wrapper": {
+        "checksum": [
+            {
+                "checksum": "checksum",
+                "type": "sha1",
+            }
+        ],
+        "content": "content",
+        "url": "url",
+    },
+    "tool_file": {
+        "file_type": "PRIMARY_DESCRIPTOR",
+        "path": "path",
+    },
+    "type": "CWL"
+}
+MOCK_CONTAINER_FILE = {
+    "file_wrapper": {
+        "checksum": [
+            {
+                "checksum": "checksum",
+                "type": "sha1",
+            }
+        ],
+        "content": "content",
+        "url": "url",
+    },
+    "tool_file": {
+        "file_type": "CONTAINERFILE",
+        "path": "path",
+    },
+    "type": "Docker"
+}
+MOCK_OTHER_FILE = {
+    "file_wrapper": {
+        "checksum": [
+            {
+                "checksum": "checksum",
+                "type": "sha1",
+            }
+        ],
+        "content": "content",
+        "url": "url",
+    },
+    "tool_file": {
+        "file_type": "OTHER",
+        "path": "path",
+    },
+    "type": "OTHER"
+}
 MOCK_FILES = [
-    {
-        "fileWrapper": {
-            "checksum": [
-                {
-                    "checksum": "checksum",
-                    "type": "sha1",
-                }
-            ],
-            "content": "content",
-            "url": "url",
-        },
-        "toolFile": {
-            "file_type": "TEST_FILE",
-            "path": "path",
-        }
-    },
-    {
-        "fileWrapper": {
-            "checksum": [
-                {
-                    "checksum": "checksum",
-                    "type": "sha2",
-                }
-            ],
-            "content": "content",
-            "url": "url",
-        },
-        "toolFile": {
-            "file_type": "CONTAINERFILE",
-            "path": "path",
-        }
-    },
+    MOCK_TEST_FILE,
+    MOCK_OTHER_FILE,
+    MOCK_CONTAINER_FILE,
+    MOCK_DESCRIPTOR_FILE,
 ]
+MOCK_TEST_FILE_INVALID = deepcopy(MOCK_TEST_FILE)
+MOCK_TEST_FILE_INVALID["type"] = "invalid"
+MOCK_OTHER_FILE_INVALID = deepcopy(MOCK_OTHER_FILE)
+MOCK_OTHER_FILE_INVALID["type"] = "invalid"
+MOCK_CONTAINER_FILE_INVALID = deepcopy(MOCK_CONTAINER_FILE)
+MOCK_CONTAINER_FILE_INVALID["type"] = "invalid"
+MOCK_DESCRIPTOR_FILE_INVALID = deepcopy(MOCK_DESCRIPTOR_FILE)
+MOCK_DESCRIPTOR_FILE_INVALID["type"] = "invalid"
 MOCK_FILES_DB_ENTRY = {
     "id": MOCK_ID,
     "versions": [
         {
             "id": MOCK_ID,
-            "files": MOCK_FILES,
+            "tests": [MOCK_TEST_FILE],
+            "others": [MOCK_OTHER_FILE],
+            "containers": [MOCK_CONTAINER_FILE],
+            "descriptors": [MOCK_DESCRIPTOR_FILE],
         }
     ],
 }
 MOCK_FILES_CONTENT_URL_MISSING = deepcopy(MOCK_FILES)
-del MOCK_FILES_CONTENT_URL_MISSING[0]['fileWrapper']['content']
-del MOCK_FILES_CONTENT_URL_MISSING[0]['fileWrapper']['url']
+del MOCK_FILES_CONTENT_URL_MISSING[0]['file_wrapper']['content']
+del MOCK_FILES_CONTENT_URL_MISSING[0]['file_wrapper']['url']
 MOCK_FILES_CHECKSUM_MISSING = deepcopy(MOCK_FILES)
-del MOCK_FILES_CHECKSUM_MISSING[0]['fileWrapper']['checksum']
+del MOCK_FILES_CHECKSUM_MISSING[0]['file_wrapper']['checksum']
+MOCK_FILE_TYPE_MISSING = [deepcopy(MOCK_FILES)[1]]
+del MOCK_FILE_TYPE_MISSING[0]['tool_file']['file_type']
+MOCK_FILES_TOOL_FILE_MISSING = [deepcopy(MOCK_FILES)[0]]
+del MOCK_FILES_TOOL_FILE_MISSING[0]['tool_file']
 MOCK_IMAGES = [
     {
         "checksum": [

--- a/trs_filer/api/additions.openapi.yaml
+++ b/trs_filer/api/additions.openapi.yaml
@@ -548,15 +548,38 @@ components:
             Other values MAY be used, as long as implementors are aware of the issues discussed in https://tools.ietf.org/html/rfc6920#section-9.4[RFC6920].
 
             GA4GH may provide more explicit guidance for use of non-IANA-registered algorithms in the future.
+    TypeRegister:
+      type: string
+      description: Type of file. For descriptor files (`PRIMARY_DESCRIPTOR`
+        and `SECONDARY_DESCRIPTOR`), the allowed file types are
+        enumerated in the `DescriptorType` schema. For container recipe files
+        (`CONTAINERFILE`), the allowed file types are enumerated in the
+        `ImageType` schema. For these files, providing this property is required.
+        For test files (`TEST_FILE`) and other files (`OTHER`), only `JSON` and
+        `OTHER` are allowed as values for this property. For these files,
+        providing the value can be omitted and will be set automatically by the
+        implementation.
+      enum:
+        - CWL
+        - WDL
+        - NFL
+        - GALAXY
+        - Docker
+        - Singularity
+        - Conda
+        - JSON
+        - OTHER
     FilesRegister:
       type: object
       description: Properties and (a pointer to the) contents of a file.
       additionalProperties: false
       properties:
-        toolFile:
+        tool_file:
           $ref: '#/components/schemas/ToolFileRegister'
-        fileWrapper:
+        file_wrapper:
           $ref: '#/components/schemas/FileWrapperRegister'
+        type:
+          $ref: '#/components/schemas/TypeRegister'
     FileWrapperRegister:
       type: object
       description: >

--- a/trs_filer/ga4gh/trs/server.py
+++ b/trs_filer/ga4gh/trs/server.py
@@ -288,9 +288,9 @@ def toolsIdVersionsVersionIdContainerfileGet(
         'versions': {
             '$elemMatch': {
                 'id': version_id,
-                'files': {
+                'containers': {
                     '$elemMatch': {
-                        'toolFile.file_type': 'CONTAINERFILE',
+                        'tool_file.file_type': 'CONTAINERFILE',
                     },
                 },
             },
@@ -303,8 +303,8 @@ def toolsIdVersionsVersionIdContainerfileGet(
     try:
         data = data['versions'][0]
         ret = [
-            d['fileWrapper'] for d in data['files']
-            if d['toolFile']['file_type'] == 'CONTAINERFILE'
+            d['file_wrapper'] for d in data['containers']
+            if d['tool_file']['file_type'] == 'CONTAINERFILE'
         ]
     except (IndexError, KeyError, TypeError):
         raise NotFound


### PR DESCRIPTION
## Description

Type information is now associated with every file when a tool (version) is registered. See issue description for detailed information.

Resolves #58