### PR TITLE
build: load app config into k8s ConfigMap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY ./ /app
 RUN cd /app \
   && python setup.py develop \
   && cd / \
-  && chmod g+w /app/trs_filer/api/
+  && chmod g+w /app/trs_filer/api/ \
+  && pip install yq
 
 CMD ["bash", "-c", "cd /app/trs_filer; python app.py"]

--- a/deployment/templates/trs-filer-configmap-job.yaml
+++ b/deployment/templates/trs-filer-configmap-job.yaml
@@ -26,6 +26,8 @@ spec:
           value: /app/trs_filer/config.yaml
         - name: APP_NAME
           value: {{ .Values.trs_filer.appName }}
+        - name: HOST_NAME
+          value:  {{ .Values.host_name }}
       restartPolicy: Never
       serviceAccountName: {{ .Values.trs_filer.appName }}-configurer
 status: {}

--- a/deployment/templates/trs-filer-configmap-job.yaml
+++ b/deployment/templates/trs-filer-configmap-job.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+data:
+  config.yaml: '# Empty, this configMap will be filled by Job (configmap-job-{{ .Values.trs_filer.appName }})'
+kind: ConfigMap
+metadata:
+  name: app-config
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configmap-job-{{ .Values.trs_filer.appName }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: certbot
+        image: {{ .Values.trs_filer.image }}
+        imagePullPolicy: Always
+        command: [ "/app/update-config-map.sh" ]
+        env:
+        - name: APISERVER
+          value: {{ .Values.apiServer }}
+        - name: CONFIG_MAP_NAME
+          value: app-config
+        - name: APP_CONFIG_PATH
+          value: /app/trs_filer/config.yaml
+        - name: APP_NAME
+          value: {{ .Values.trs_filer.appName }}
+      restartPolicy: Never
+      serviceAccountName: {{ .Values.trs_filer.appName }}-configurer
+status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: {{ .Values.trs_filer.appName }}-configurer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-{{ .Values.trs_filer.appName }}-configurer
+roleRef:
+  name: admin
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.trs_filer.appName }}-configurer

--- a/deployment/templates/trs-filer-deploy.yaml
+++ b/deployment/templates/trs-filer-deploy.yaml
@@ -30,9 +30,21 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /app/trs_filer/config.yaml
+          name: config-yaml
+          subPath: config.yaml
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+            - key: config.yaml
+              path: config.yaml
+          name: app-config
+        name: config-yaml
 status:

--- a/deployment/templates/trs-filer-deploy.yaml
+++ b/deployment/templates/trs-filer-deploy.yaml
@@ -1,14 +1,14 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: trs-filer
+  name: {{ .Values.trs_filer.appName }}
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: trs-filer
+      app: {{ .Values.trs_filer.appName }}
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -18,12 +18,12 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        app: trs-filer
+        app: {{ .Values.trs_filer.appName }}
     spec:
       containers:
       - image: {{ .Values.trs_filer.image }}
         imagePullPolicy: Always
-        name: trs-filer
+        name: {{ .Values.trs_filer.appName }}
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/deployment/templates/trs-filer-route.yaml
+++ b/deployment/templates/trs-filer-route.yaml
@@ -2,17 +2,17 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: trs-filer
+  name: {{ .Values.trs_filer.appName }}
 spec:
   host: {{ .Values.host_name }}
   port:
-    targetPort: trs-filer
+    targetPort: {{ .Values.trs_filer.appName }}
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
   to:
     kind: Service
-    name: trs-filer
+    name: {{ .Values.trs_filer.appName }}
     weight: 100
   wildcardPolicy: None
 status:

--- a/deployment/templates/trs-filer-service.yaml
+++ b/deployment/templates/trs-filer-service.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: trs-filer
+  name: {{ .Values.trs_filer.appName }}
 spec:
   ports:
-  - name: trs-filer
+  - name: {{ .Values.trs_filer.appName }}
     port: 8080
     protocol: TCP
     targetPort: 8080
   selector:
-    app: trs-filer
+    app: {{ .Values.trs_filer.appName }}
   sessionAffinity: None
   type: ClusterIP
 status:

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -8,6 +8,9 @@ host_name: trs-filer-test.c03.k8s-popup.csc.fi
 
 trs_filer:
   image: lvarin/trs-filer:0.1.0
+  appName: trs-filer
+
+apiServer: kubernetes.default.svc:443 # address of k8s API server
 
 mongodb:
   image: mongo:3.6

--- a/update-config-map.sh
+++ b/update-config-map.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# This script is meant to be run inside a Kubernetes pod
+#
+###############################################################################
+
+if [ -z "$CONFIG_MAP_NAME" -o -z "$APISERVER" -o -z "$APP_CONFIG_PATH" -o -z "$APP_NAME" ];
+then
+	echo "CONFIG_MAP_NAME, APISERVER, APP_CONFIG_PATH, and APP_NAME env vars required"
+	env
+	exit 1
+fi
+echo "Inputs:"
+echo " CONFIG MAP NAME: $CONFIG_MAP_NAME"
+echo " API SERVER:      $APISERVER"
+echo " APP CONFIG PATH: $APP_CONFIG_PATH"
+echo " WES APP NAME:    $APP_NAME"
+
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
+if [ -z "$NAMESPACE" ];
+then
+  echo "ERROR: Cannot get the namespace from '/var/run/secrets/kubernetes.io'" >&2
+  echo "This script is meant to be run inside a Kubernetes pod only." >&2
+  exit -1
+fi
+
+echo "Current Kubernetes namespace: $NAMESPACE"; echo
+
+echo " * Getting current default configuration"
+
+APP_CONFIG=$(cat "$APP_CONFIG_PATH") || exit 4
+
+echo " * Getting current configMap"
+curl -s \
+  --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -X GET \
+  -H "Accept: application/json, */*" \
+  -o /tmp/configmap.json \
+  -w "Return HTTP/code: %{http_code}\n\n" \
+"https://$APISERVER/api/v1/namespaces/${NAMESPACE}/configmaps/${CONFIG_MAP_NAME}"
+
+echo " * Validating JSON file recevied:"; echo
+jq . /tmp/configmap.json || exit 2
+
+echo " JSON file is valid";echo
+
+echo " * Creating update for secret"
+jq --arg APP_CONFIG "$APP_CONFIG" '.data."config.yaml" = $APP_CONFIG' /tmp/configmap.json >/tmp/configmap-patch.json || exit 5
+
+echo " * Validating JSON file patched:"; echo
+jq . /tmp/configmap-patch.json || exit 3
+
+echo " JSON file is valid";echo
+
+# Update Config map
+echo " * Updating config map"
+curl -s \
+  --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -X PATCH \
+  -H "Accept: application/json, */*" \
+  -H "Content-Type: application/strategic-merge-patch+json" \
+  -d @/tmp/configmap-patch.json "https://$APISERVER/api/v1/namespaces/${NAMESPACE}/configmaps/${CONFIG_MAP_NAME}" \
+  -o /dev/null
+
+echo " * Deleting current $APP_NAME pod"
+curl -s \
+  --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -X GET \
+  -H "Accept: application/json, */*" \
+  "https://$APISERVER/api/v1/namespaces/${NAMESPACE}/pods/" | \
+jq '.items | .[] | .metadata.name ' -r | grep "^${APP_NAME}-" | \
+while read pod;
+do
+  echo "   - Deleting: $pod"
+  curl -s \
+    --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    -X DELETE \
+    -H "Accept: application/json, */*" \
+    -o /dev/null \
+    "https://$APISERVER/api/v1/namespaces/${NAMESPACE}/pods/$pod"
+done
+
+echo " All Done"
+
+sleep 3600
+
+


### PR DESCRIPTION
Loads app configuration from `config.yaml` into a `ConfigMap` in the container so that it can be modified on a running service on the fly. In particular, adds a job that gets the default configuration, replaces specific deployment-specific parameters to provide self reference URLs to resources on the deployed service, registers the modified config as a `ConfigMap` object and mounts it.

Resolves #21