### PR TITLE
fix: decode relative paths

### DIFF
--- a/trs_filer/ga4gh/trs/server.py
+++ b/trs_filer/ga4gh/trs/server.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import (Optional, Dict, List, Tuple)
+from urllib.parse import unquote
 
 from flask import (request, current_app)
 from foca.utils.logging import log_traffic
@@ -298,12 +299,16 @@ def toolsIdVersionsVersionIdTypeDescriptorRelativePathGet(
         version_id: Tool version identifier.
         relative_path: A relative path to the additional file (same directory
         or subdirectories), for example 'foo.cwl' would return a 'foo.cwl'
-        from the same directory as the main descriptor.
+        from the same directory as the main descriptor. Needs to be percent/url
+        encoded/quoted.
 
     Returns:
         Additional files associated with a given descriptor type of a given
         tool version.
     """
+    logger.debug(f"Encoded relative path: '{relative_path}'")
+    relative_path = unquote(relative_path)
+    logger.debug(f"Decoded relative path: '{relative_path}'")
     ret = {}
     validate_descriptor_type(type=type)
 


### PR DESCRIPTION
OpenAPI 3.0 does not allow [slashes in path parameters](https://github.com/OAI/OpenAPI-Specification/issues/892). However, the [TRS specs explicitly allow/encourage](https://github.com/ga4gh/tool-registry-service-schemas/blob/1059c7ca1193dd2bccc8fc8be94581d16e7189bd/openapi/openapi.yaml#L344) to use relative paths including forward slashes for the `relative_path` parameter in `GET /tools/{id}/versions/{version_id}/{type}/descriptor/{relative_path}`. As this cannot readily be achieved with OpenAPI, TRS-Filer will require any client to provide percent-encoded paths for this endpoint (though not during registration!).

This PR implements decoding of the `relative_path` path parameter in the controller of the above-mentioned API endpoint.