### PR TITLE
fix: unique paths for files of descriptor type

### DIFF
--- a/tests/ga4gh/trs/endpoints/test_register_objects.py
+++ b/tests/ga4gh/trs/endpoints/test_register_objects.py
@@ -403,6 +403,27 @@ class TestRegisterToolVersion:
                 tool.data['files'] = [mock_file]
                 tool.process_files()
 
+    def test_process_files_non_unique_paths(self):
+        """Test for processing when file objects don't have unique
+        paths."""
+        app = Flask(__name__)
+        app.config['FOCA'] = Config(
+            db=MongoConfig(**MONGO_CONFIG),
+            endpoints=ENDPOINT_CONFIG_CHARSET_LITERAL,
+        )
+
+        data = deepcopy(MOCK_VERSION_NO_ID)
+        tmp_file_obj1 = deepcopy(MOCK_DESCRIPTOR_FILE)
+        tmp_file_obj2 = deepcopy(MOCK_DESCRIPTOR_SEC_FILE)
+        tmp_file_obj1["tool_file"]["path"] = "tmp_url"
+        tmp_file_obj2["tool_file"]["path"] = "tmp_url"
+        data['files'] = [tmp_file_obj1, tmp_file_obj2]
+        with app.app_context():
+            with pytest.raises(BadRequest):
+                tool = RegisterToolVersion(data=data, id=MOCK_ID)
+                tool.data['files'] = data['files']
+                tool.process_files()
+
     def test_process_files_no_content(self, monkeypatch):
         """Test for processing files with no content provided."""
         app = Flask(__name__)

--- a/tests/ga4gh/trs/endpoints/test_register_objects.py
+++ b/tests/ga4gh/trs/endpoints/test_register_objects.py
@@ -362,7 +362,9 @@ class TestRegisterToolVersion:
         )
 
         data = deepcopy(MOCK_VERSION_NO_ID)
-        data['files'].append(MOCK_DESCRIPTOR_FILE)
+        mock_descriptor = deepcopy(MOCK_DESCRIPTOR_FILE)
+        mock_descriptor['tool_file']['path'] = 'random_path'
+        data['files'].append(mock_descriptor)
         with app.app_context():
             with pytest.raises(BadRequest):
                 tool = RegisterToolVersion(data=data, id=MOCK_ID)

--- a/tests/ga4gh/trs/test_server.py
+++ b/tests/ga4gh/trs/test_server.py
@@ -450,7 +450,7 @@ def test_toolsIdVersionsVersionIdTypeDescriptorRelativePathGet():
                 type='CWL',
                 id=MOCK_ID,
                 version_id=MOCK_ID,
-                relative_path='path_tmp',
+                relative_path='path_sec_desc_cwl',
             )
         assert res == MOCK_DESCRIPTOR_SEC_FILE["file_wrapper"]
 

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -113,7 +113,7 @@ MOCK_TEST_FILE = {
     },
     "tool_file": {
         "file_type": "TEST_FILE",
-        "path": "path",
+        "path": "path_test_cwl",
     },
     "type": "CWL",
 }
@@ -130,7 +130,7 @@ MOCK_DESCRIPTOR_FILE = {
     },
     "tool_file": {
         "file_type": "PRIMARY_DESCRIPTOR",
-        "path": "path",
+        "path": "path_prim_desc_cwl",
     },
     "type": "CWL",
 }
@@ -147,7 +147,7 @@ MOCK_DESCRIPTOR_SEC_FILE = {
     },
     "tool_file": {
         "file_type": "SECONDARY_DESCRIPTOR",
-        "path": "path_tmp",
+        "path": "path_sec_desc_cwl",
     },
     "type": "CWL"
 }
@@ -164,7 +164,7 @@ MOCK_CONTAINER_FILE = {
     },
     "tool_file": {
         "file_type": "CONTAINERFILE",
-        "path": "path",
+        "path": "path_container_docker",
     },
     "type": "Docker",
 }
@@ -181,7 +181,7 @@ MOCK_OTHER_FILE = {
     },
     "tool_file": {
         "file_type": "OTHER",
-        "path": "path",
+        "path": "path_other_cwl",
     },
     "type": "CWL"
 }

--- a/trs_filer/ga4gh/trs/endpoints/register_objects.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_objects.py
@@ -320,6 +320,7 @@ class RegisterToolVersion:
     def process_files(self) -> None:
         """Process file (meta)data."""
         self.files['id'] = self.data['id']
+        file_path_array = []
 
         # validate file types
         file_types = defaultdict(list)
@@ -417,6 +418,13 @@ class RegisterToolVersion:
                     logger.error("Missing or invalid image file type.")
                     raise BadRequest
                 self.files['containers'].append(_file)
+
+            # validate unique paths
+            if _file['tool_file']['path'] not in file_path_array:
+                file_path_array.append(_file['tool_file']['path'])
+            else:
+                logger.error("Duplicate file paths not allowed.")
+                raise BadRequest
 
     def register_metadata(self) -> None:
         """Register version with tool."""


### PR DESCRIPTION
* return `400/BadRequest` when registering a tool / version if not all files associated with a given descriptor type have unique paths

Fixes #70