### PR TITLE
fix: various issues with files & versions

### DIFF
--- a/trs_filer/ga4gh/trs/endpoints/register_objects.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_objects.py
@@ -410,6 +410,7 @@ class RegisterToolVersion:
                 if _file['type'] not in self.descriptor_types:
                     logger.error("Invalid descriptor type.")
                     raise BadRequest
+                self.files['descriptors'].append(_file)
 
             # validate image file types
             elif _file['tool_file']['file_type'] == "CONTAINERFILE":

--- a/trs_filer/ga4gh/trs/endpoints/register_objects.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_objects.py
@@ -122,7 +122,10 @@ class RegisterTool:
             )
 
             # process version information
-            version_list = [v.get('id', None) for v in self.data['versions']]
+            version_list = [
+                v.get('id', None) for v in self.data['versions']
+                if v.get('id', None) is not None
+            ]
             if len(version_list) != len(set(version_list)):
                 logger.error("Duplicate tool version IDs specified.")
                 raise BadRequest

--- a/trs_filer/ga4gh/trs/endpoints/register_objects.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_objects.py
@@ -310,14 +310,8 @@ class RegisterToolVersion:
         )
 
         # process files
+        self.process_files()
         if 'files' in self.data:
-            # Set `containerfile` property
-            self.data['containerfile'] = False
-            for _file in self.data['files']:
-                if _file['tool_file']['file_type'] == "CONTAINERFILE":
-                    self.data['containerfile'] = True
-                    break
-            self.process_files()
             self.data.pop('files')
 
     def process_files(self) -> None:
@@ -326,7 +320,7 @@ class RegisterToolVersion:
 
         # validate file types
         file_types = defaultdict(list)
-        for f in self.data['files']:
+        for f in self.data.get('files', []):
             file_types[f['type']].append(f['tool_file']['file_type'])
         invalid = False
         for d_type, f_types in file_types.items():
@@ -357,7 +351,7 @@ class RegisterToolVersion:
             raise BadRequest
 
         # validate required fields
-        for _file in self.data['files']:
+        for _file in self.data.get('files', []):
 
             # validate conditionally required properties
             if (


### PR DESCRIPTION
* allow registering tools that have no associated versions (i.e., empty version list in JSON payload); allow deleting the last remaining version of a tool (#78)
* allow deleting a version that has no associated files (#79)
* include descriptor-associated files in files database collection (#80)
* allow registering multiple versions without specifying version identifiers (#81)

Fixes #78 
Fixes #79 
Fixes #80 
Fixes #81