### PR TITLE
fix: register tools without tool class identifier

### DIFF
--- a/tests/ga4gh/trs/endpoints/test_register_objects.py
+++ b/tests/ga4gh/trs/endpoints/test_register_objects.py
@@ -233,6 +233,25 @@ class TestRegisterTool:
                 tool = RegisterTool(data=data)
                 tool.register_metadata()
 
+    def test_register_metadata_without_tool_class_identifier(self):
+        """Test for creating a tool with tool class without an identifier."""
+        app = Flask(__name__)
+        app.config['FOCA'] = Config(
+            db=MongoConfig(**MONGO_CONFIG),
+            endpoints=ENDPOINT_CONFIG_TOOL_CLASS_VALIDATION,
+        )
+        app.config['FOCA'].db.dbs['trsStore'].collections['tools'] \
+            .client = MagicMock()
+        app.config['FOCA'].db.dbs['trsStore'].collections['toolclasses'] \
+            .client = MagicMock()
+
+        data = deepcopy(MOCK_TOOL_VERSION_ID)
+        data["toolclass"].pop("id")
+        with app.app_context():
+            tool = RegisterTool(data=data)
+            tool.register_metadata()
+            assert isinstance(tool.data['id'], str)
+
     def test_register_metadata_tool_duplicate_key(self):
         """Test for creating a tool; duplicate key error occurs."""
         app = Flask(__name__)

--- a/trs_filer/ga4gh/trs/endpoints/register_objects.py
+++ b/trs_filer/ga4gh/trs/endpoints/register_objects.py
@@ -116,6 +116,15 @@ class RegisterTool:
                 f"{self.api_path}/tools/{self.data['id']}"
             )
 
+            # set tool class identifier if not present
+            tool_class_id = self.data['toolclass'].get('id', None)
+            if tool_class_id is None:
+                tool_class_id = generate_id(
+                    charset=self.id_charset,
+                    length=self.id_length
+                )
+                self.data['toolclass']['id'] = tool_class_id
+
             # process version information
             version_list = [
                 v.get('id', None) for v in self.data['versions']


### PR DESCRIPTION
## Description

`POST`ing or `PUT`ting a tool without specifying a tool class identifier returned a `500/InternalServerError` response because of a `KeyError` in [this line](https://github.com/elixir-cloud-aai/trs-filer/blob/4cd8dd9c2839ec0f4c4e84645daaceafd614184c/trs_filer/ga4gh/trs/endpoints/register_objects.py#L188).

* Where necessary, tool classes will now be added on the fly when registering tools. Tool class identifiers are randomly generated in this case.

Fixes #77