### PR TITLE
Added K8s ingress on helm chart deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ curl -X GET "http://localhost:8080/ga4gh/trs/v2/tools" -H "accept: application/j
 To quickly install the service for development/testing purposes, we recommend
 deployment via [`docker-compose`][res-docker-compose], as described below. For
 more durable deployments on cloud native infrastructure, we also provide a
-[Helm][res-helm] chart and [basic deployment instructions][trs-filer-
-deployment] (details may need to be adapted for your specific infrastructure).
+[Helm][res-helm] chart and [basic deployment instructions][trs-filer-deployment] (details may need to be adapted for your specific infrastructure).
 
 ### Requirements
 

--- a/deployment/templates/trs-filer-deploy.yaml
+++ b/deployment/templates/trs-filer-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.trs_filer.appName }}

--- a/deployment/templates/trs-filer-route.yaml
+++ b/deployment/templates/trs-filer-route.yaml
@@ -18,13 +18,16 @@ spec:
 status:
   ingress: []
 {{ else if eq .Values.clusterType "kubernetes" }}
+{{ if .Values.kubernetes.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{ if .Values.kubernetes.ingress.enabled }}
+    cert-manager.io/cluster-issuer: {{ .Values.kubernetes.https.issuer }}
     kubernetes.io/tls-acme: "true"
+    {{ end }}
   name: {{ .Values.trs_filer.appName }}-ingress
 spec:
   rules:
@@ -38,8 +41,11 @@ spec:
               number: 8080
         path: /
         pathType: Prefix
+{{ if .Values.kubernetes.https.enabled }}
   tls:
   - hosts:
     - {{ .Values.host_name }}
     secretName: {{ .Values.trs_filer.appName }}-ingress-secret
+{{ end }}
+{{ end }}
 {{ end }}

--- a/deployment/templates/trs-filer-route.yaml
+++ b/deployment/templates/trs-filer-route.yaml
@@ -17,4 +17,29 @@ spec:
   wildcardPolicy: None
 status:
   ingress: []
+{{ else if eq .Values.clusterType "kubernetes" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+  name: {{ .Values.trs_filer.appName }}-ingress
+spec:
+  rules:
+  - host: {{ .Values.host_name }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Values.trs_filer.appName }}
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - {{ .Values.host_name }}
+    secretName: {{ .Values.trs_filer.appName }}-ingress-secret
 {{ end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -2,9 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-clusterType: openshift
+clusterType: kubernetes
 
-host_name: trs-filer-test.c03.k8s-popup.csc.fi
+host_name: trs.hypatia-comp.athenarc.gr
 
 trs_filer:
   image: lvarin/trs-filer:0.1.0
@@ -14,4 +14,4 @@ apiServer: kubernetes.default.svc:443 # address of k8s API server
 
 mongodb:
   image: mongo:3.6
-  volumeSize: 1Gi
+  volumeSize: 10Gi

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -2,9 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-clusterType: kubernetes
+clusterType: openshift
 
-host_name: trs.hypatia-comp.athenarc.gr
+host_name: trs-filer-test.c03.k8s-popup.csc.fi
 
 trs_filer:
   image: lvarin/trs-filer:0.1.0
@@ -12,6 +12,17 @@ trs_filer:
 
 apiServer: kubernetes.default.svc:443 # address of k8s API server
 
+# If you are running kubernetes select whether you would like
+# to access the service via Ingress. Also, if you have the cert manager
+# installed, you can provision a certificate for https
+kubernetes:
+  ingress:
+    enabled: true
+  https:
+    enabled: true
+    issuer: prod-issuer
+
 mongodb:
   image: mongo:3.6
-  volumeSize: 10Gi
+  volumeSize: 1Gi
+


### PR DESCRIPTION
## Description

This PR adds an ingress definition when one runs on K8s with options to enable/disable both the ingress and https. Also fixed link on the README.md file.

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [ ] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [x] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable