### PR TITLE
Allow the confoguration of the mongodb host, adds flexibility to the …

### DIFF
--- a/deployment/templates/trs-filer-configmap-job.yaml
+++ b/deployment/templates/trs-filer-configmap-job.yaml
@@ -28,6 +28,8 @@ spec:
           value: {{ .Values.trs_filer.appName }}
         - name: HOST_NAME
           value:  {{ .Values.host_name }}
+        - name: MONGO_HOST
+          value: mongodb-{{ .Values.trs_filer.appName }}
       restartPolicy: Never
       serviceAccountName: {{ .Values.trs_filer.appName }}-configurer
 status: {}

--- a/update-config-map.sh
+++ b/update-config-map.sh
@@ -11,7 +11,7 @@ then
 	exit 1
 fi
 
-if [[ -z "$MONGO_HOST" ]];
+if [ -z "$MONGO_HOST" ];
 then
   MONGO_HOST='mongodb'
 fi

--- a/update-config-map.sh
+++ b/update-config-map.sh
@@ -11,7 +11,7 @@ then
 	exit 1
 fi
 
-if [ -z "$MONGO_HOST" ];
+if [[ -z "$MONGO_HOST" ]];
 then
   MONGO_HOST='mongodb'
 fi

--- a/update-config-map.sh
+++ b/update-config-map.sh
@@ -10,12 +10,19 @@ then
 	env
 	exit 1
 fi
+
+if [ -z "$MONGO_HOST" ];
+then
+  MONGO_HOST='mongodb'
+fi
+
 echo "Inputs:"
 echo " CONFIG MAP NAME: $CONFIG_MAP_NAME"
 echo " API SERVER:      $APISERVER"
 echo " APP CONFIG PATH: $APP_CONFIG_PATH"
 echo " WES APP NAME:    $APP_NAME"
 echo " HOST NAME:       $HOST_NAME"
+echo " MONGO_HOST:      $MONGO_HOST"
 
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 
@@ -31,9 +38,11 @@ echo "Current Kubernetes namespace: $NAMESPACE"; echo
 echo " * Getting current default configuration"
 
 APP_CONFIG=$(yq --arg HOST_NAME "$HOST_NAME" \
+    --arg MONGO_HOST "$MONGO_HOST" \
     '.endpoints.service.url_prefix = "https" |
      .endpoints.service.external_host = $HOST_NAME |
-     .endpoints.service.external_port = 443' \
+     .endpoints.service.external_port = 443 |
+     .db.host = $MONGO_HOST' \
     "$APP_CONFIG_PATH") || exit 4
 
 echo " * Getting current configMap"


### PR DESCRIPTION
…chart

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [x] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [x] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to configure the MongoDB host via an environment variable, enhancing the flexibility of the deployment configuration.

- **New Features**:
    - Added the ability to configure the MongoDB host through an environment variable in the update-config-map.sh script.
- **Enhancements**:
    - Updated the trs-filer-configmap-job.yaml to include the MONGO_HOST environment variable, allowing for dynamic MongoDB host configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->