### PR TITLE
build: add startup command to Dockerfile

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -49,14 +49,14 @@ jobs:
           fail_ci_if_error: true
           verbose: true
       - name: Deploy app
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
       - name: Wait for app startup
         run: sleep 20
       - name: Run integration tests
         shell: bash
         run: pytest tests/integration_tests.py
       - name: Tear down app
-        run: docker-compose down
+        run: docker compose down
 
   Publish:
     name: Build and publish app image

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,4 @@ RUN pip install -e .
 ## (required by FOCA)
 RUN chmod -R a+rwx /app/trs_filer/api
 
+CMD ["bash", "-c", "cd /app/trs_filer && gunicorn -c gunicorn.py wsgi:app"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
         restart: unless-stopped
         links:
             - mongodb
-        command: bash -c "cd /app/trs_filer; gunicorn -c gunicorn.py wsgi:app"
         ports:
             - "80:8080"
 


### PR DESCRIPTION
## Description

Fix TRS Filer container entrypoint for persistent deployment

This patch updates the Dockerfile to set a proper CMD that launches the TRS Filer server via gunicorn, so it runs as a persistent service instead of exiting like a one-off job. The command override in docker-compose.yaml has been removed to avoid conflicting with the new default.

Context: The elixircloud/trs-filer:latest image doesn’t work as expected for TRS deployment—it behaves like a short-lived job.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not reduced the existing code coverage
- [ ] I have added docstrings following the [Python style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/python.md) of this project to all new modules, classes, methods and functions are documented with docstrings following; I have updated any previously existing docstrings, if applicable
- [ ] I have updated any sections of the app's documentation that are affected by the proposed changes, if applicable

## Summary by Sourcery

Build:
- Add the `CMD` instruction to the Dockerfile to start the `gunicorn` server when the container runs.